### PR TITLE
`onEach` modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,26 @@ let value = try await withExponentialBackoff()
 Note that you can use `cancellableValue` instead of `value`. In this case, if the task wrapping the concurrency context
 is cancelled, the underlying retrier will be cancelled.
 
+## Simple events handling
+
+Retrier events can be handled simply.
+
+```swift
+fetcher.onEach {
+    switch $0 {
+        case .attemptSuccess(let value):
+            print("Fetched something: \(value)")
+        case .attemptFailure(let failure):
+            print("An attempt #\(failure.index) failed with \(failure.error)")
+        case .completion(let error):
+            print("Fetcher completed with \(error?.localizedDescription ?? "no error")")
+    }
+}
+```
+
+Keep in mind that the event handler will be retained until the retrier finishes (succeeding, failing or being 
+cancelled).
+
 ## Combine publishers
 
 All retriers (including repeaters) expose Combine publishers that publish relevant events.

--- a/Sources/SwiftRetrier/Util/Retrier+OnEach.swift
+++ b/Sources/SwiftRetrier/Util/Retrier+OnEach.swift
@@ -1,0 +1,13 @@
+import Combine
+
+public extension Retrier {
+
+    func onEach(handleEvent: @escaping (RetrierEvent<Output>) -> Void) -> Self {
+        var subscription: AnyCancellable?
+        subscription = publisher()
+            .sink(receiveCompletion: { _ in
+                subscription?.cancel()
+            }, receiveValue: handleEvent)
+        return self
+    }
+}


### PR DESCRIPTION
Not an actual modifier.
It is ensured is that when the retrier finished (success / failure / cancellation), `onEach` subscription will be canceled after the final event.